### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ cache       = "2.2.1"
 httpClient  = "3.2.2"
 license     = "3.1.0"
 router      = "3.2.0"
-util        = "3.1.1"
+util        = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-graphql     = { module = "com.enonic.lib:lib-graphql",     version.ref = "graphql" }


### PR DESCRIPTION
## Summary

Pin `lib-util` to the next-major SNAPSHOT published from its master branch as part of the XP 8 upgrade. We are not releasing these libs yet, so consumers point directly at the SNAPSHOT and resolve from the Enonic dev/snapshot Maven repo.

## Bumped

| Library | Before | After |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` *(SNAPSHOT, resolves from `xp.enonicRepo('dev')`)* |

`lib-menu` and `lib-explorer` are also part of the XP 8 lib-major bump set, but this repo does not consume them, so nothing to bump there.

## Repositories

No change. `build.gradle` already declares `xp.enonicRepo('dev')`, which is what resolves the SNAPSHOT.

## Excludes audit

No `exclude` clauses on any lib dependency in `build.gradle` (only `processResources` file-pattern excludes, which are unrelated). Nothing to remove or keep.

## Stop conditions

None hit. Pre-flight passed (`xpVersion=8.0.0-B4`), `./gradlew clean build` is green, dependency tree shows `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` resolving cleanly.

## Verification

- `./gradlew clean build` — BUILD SUCCESSFUL (jest: 542/542 tests passed).
- `./gradlew dependencies --configuration runtimeClasspath` — confirms `lib-util:4.0.0-SNAPSHOT` resolves.
- Runtime verification (deploying against an XP 8 server) was **not** performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)