### PR TITLE
Bump version to 5.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Branches the XP 7 maintenance line off and prepares master for XP 8.

- Maintenance branch `4.x` was created at `89e5d7b` ("Next SNAPSHOT" — `version=4.5.1-SNAPSHOT`, the first post-`v4.5.0` SNAPSHOT commit), so the release tooling can keep cutting 4.x patch releases without re-releasing `v4.5.0`.
- `gradle.properties` already declares `version=5.0.0-SNAPSHOT` on master, so no version edit is needed here.
- Adds `releaseBranch:` to the workflow so pushes to both `master` and `4.x` are recognized as release-branch builds (`build-and-publish` reads this list).

Reference: app-booster's `master` ↔ `1.x` split.