### PR TITLE
Add release-branch CI config for 4.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            4.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the `releaseBranch:` block to the workflow on the new XP 7 maintenance branch so pushes to `4.x` are recognized as release-branch builds. The release tooling reads the list from the workflow file on the *branch being built*, so the same edit must land on both `master` and `4.x` (companion PR: #381).

No version bump or other changes here — `gradle.properties` already declares `version=4.5.1-SNAPSHOT` on this branch (the post-`v4.5.0` SNAPSHOT commit it was branched from).

Reference: app-booster's `master` ↔ `1.x` split.