### PR TITLE
Vendor in toStr/getSites/ids from lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
 	implementation libs.lib.router
 
 	//implementation 'com.enonic.lib:text-encoding:1.2.0'
-	implementation libs.lib.util
 
 	// WARNING: Do NOT use compile files, jar file will be missing dependencies!
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ cache       = "3.0.0-SNAPSHOT"
 httpClient  = "4.0.0-SNAPSHOT"
 license     = "4.0.0-SNAPSHOT"
 router      = "4.0.0-SNAPSHOT"
-util        = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-graphql     = { module = "com.enonic.lib:lib-graphql",     version.ref = "graphql" }
@@ -14,4 +13,3 @@ lib-cache       = { module = "com.enonic.lib:lib-cache",       version.ref = "ca
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "httpClient" }
 lib-license     = { module = "com.enonic.lib:lib-license",     version.ref = "license" }
 lib-router      = { module = "com.enonic.lib:lib-router",      version.ref = "router" }
-lib-util        = { module = "com.enonic.lib:lib-util",        version.ref = "util" }

--- a/src/main/resources/lib/explorer/content/getSites.ts
+++ b/src/main/resources/lib/explorer/content/getSites.ts
@@ -1,0 +1,61 @@
+//@ts-ignore
+import {query as queryContent} from '/lib/xp/content';
+//@ts-ignore
+import {get as getContext, run} from '/lib/xp/context';
+
+
+interface QueryContentParams {
+	aggregations?: unknown;
+	contentTypes?: Array<string>;
+	count?: number;
+	filters?: unknown;
+	query?: string;
+	sort?: string;
+	start?: number;
+}
+
+
+export interface GetSitesParams {
+	aggregations?: unknown;
+	branch?: string;
+	context?: Record<string, unknown>;
+	count?: number;
+	filters?: unknown;
+	map?: (hit: unknown) => unknown;
+	query?: string;
+	sort?: string;
+	start?: number;
+}
+
+
+export function getSites({
+	aggregations,
+	branch,
+	context = (() => {
+		const c = getContext() as unknown as Record<string, unknown>;
+		if (branch) { c.branch = branch; }
+		return c;
+	})(),
+	count = -1,
+	filters,
+	map,
+	query,
+	sort,
+	start
+}: GetSitesParams = {}) {
+	const queryParams: QueryContentParams = {
+		aggregations,
+		count,
+		contentTypes: ['portal:site'],
+		filters,
+		query,
+		sort,
+		start
+	};
+
+	const childRes = run(context, () => queryContent(queryParams));
+	if (typeof map === 'function') {
+		childRes.hits = childRes.hits.map((c: unknown) => map(c));
+	}
+	return childRes;
+}

--- a/src/main/resources/lib/explorer/index.ts
+++ b/src/main/resources/lib/explorer/index.ts
@@ -6,5 +6,8 @@ export * from '/lib/explorer/constants'; // ReferenceError: "APP_EXPLORER" is no
 //export {list as getApplications} from '/lib/explorer/application';
 export {create, update} from '/lib/explorer/document';
 export {register, unregister, Collector} from '/lib/explorer/collector';
+export {getSites} from '/lib/explorer/content/getSites';
+export {ids} from '/lib/explorer/query/ids';
+export {toStr} from '/lib/explorer/util/toStr';
 
 //export * as repo from './repo';

--- a/src/main/resources/lib/explorer/util/toStr.ts
+++ b/src/main/resources/lib/explorer/util/toStr.ts
@@ -1,0 +1,14 @@
+type ReplacerFn = (this: unknown, key: string, value: unknown) => unknown;
+type Replacer = ReplacerFn | Array<string | number> | null;
+
+
+export const toStr = (
+	value: unknown,
+	replacer: Replacer = null,
+	space: string | number = 4
+): string => JSON.stringify(value, replacer as ReplacerFn, space);
+
+
+export default {
+	toStr
+};

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -46,7 +46,6 @@ export default defineConfig((options: MyOptions) => {
 				'/lib/graphql-connection',
 				'/lib/http-client',
 				'/lib/router',
-				'/lib/util',
 				'/lib/vanilla',
 				'/lib/thymeleaf',
 				'/lib/xp/admin',


### PR DESCRIPTION
## Summary

- Vendor `toStr`, `getSites`, and `ids` from lib-util into lib-explorer so the explorer cluster can drop its dependency on `com.enonic.lib:lib-util` entirely.
- `lib/explorer/query/ids.ts` already existed — just exposed from the barrel.
- `lib/explorer/util/toStr.ts` and `lib/explorer/content/getSites.ts` are new, matching lib-util's signatures and runtime behaviour.
- Removed the `lib-util` entry from `gradle/libs.versions.toml`, the matching `implementation` line in `build.gradle`, and the now-unused `/lib/util` external in `tsup.config.ts`.

## Test plan

- [x] `./gradlew build` — 542 unit tests pass, tsc check passes, tsup bundles emit `build/resources/main/lib/explorer/{util/toStr,content/getSites,query/ids}.js`.
- [ ] Follow-up: `app-explorer` and `app-explorer-collector-site` will switch their `/lib/util/...` imports to `/lib/explorer/...` in separate PRs once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)