### PR TITLE
GraalJS Compatibility #425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 	testImplementation "com.enonic.xp:testing:${xpVersion}"
 	testImplementation 'org.junit.jupiter:junit-jupiter:6.1.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 tasks.withType( Copy ).configureEach {
@@ -130,19 +129,11 @@ tasks.named('compileTestJava') {
 	dependsOn npmBuild
 }
 
+xp {
+	scriptEngines = ['Nashorn', 'GraalJS']
+}
+
 test {
 	dependsOn npmBuild
 	useJUnitPlatform()
 }
-
-def testGraalJs = tasks.register('testGraalJs', Test) {
-	group = 'verification'
-	description = 'Runs tests with the GraalJS script engine.'
-	dependsOn npmBuild
-	useJUnitPlatform()
-	testClassesDirs = sourceSets.test.output.classesDirs
-	classpath = sourceSets.test.runtimeClasspath
-	systemProperty 'xp.script-engine', 'GraalJS'
-	shouldRunAfter test
-}
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,14 @@ dependencies {
 	//implementation 'com.enonic.lib:text-encoding:1.2.0'
 
 	// WARNING: Do NOT use compile files, jar file will be missing dependencies!
+
+	//──────────────────────────────────────────────────────────────────────────
+	// Test
+	//──────────────────────────────────────────────────────────────────────────
+	testImplementation "com.enonic.xp:testing:${xpVersion}"
+	testImplementation 'org.junit.jupiter:junit-jupiter:6.1.1'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 tasks.withType( Copy ).configureEach {
@@ -117,3 +125,24 @@ processResources {
 
 jar.dependsOn npmBuild
 javadoc.dependsOn npmBuild
+
+tasks.named('compileTestJava') {
+	dependsOn npmBuild
+}
+
+test {
+	dependsOn npmBuild
+	useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+	group = 'verification'
+	description = 'Runs tests with the GraalJS script engine.'
+	dependsOn npmBuild
+	useJUnitPlatform()
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	systemProperty 'xp.script-engine', 'GraalJS'
+	shouldRunAfter test
+}
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ nodeVersion=24.18.0
 
 version=5.0.0-SNAPSHOT
 
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.enonic.xp.settings' version '4.1.0'
+	id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = rootProjectName

--- a/src/main/resources/lib/explorer/http/client/smartRequest.ts
+++ b/src/main/resources/lib/explorer/http/client/smartRequest.ts
@@ -16,6 +16,12 @@ interface StateRef {
 
 //@ts-ignore TODO Add global types in tsconfig.json
 const {currentTimeMillis} = Java.type('java.lang.System');
+//@ts-ignore
+const ConnectException = Java.type('java.net.ConnectException');
+//@ts-ignore
+const SocketTimeoutException = Java.type('java.net.SocketTimeoutException');
+//@ts-ignore
+const NullPointerException = Java.type('java.lang.NullPointerException');
 
 
 type SmartRequestParams = HttpClient.Request & {
@@ -96,11 +102,9 @@ export function smartRequest(smartRequestParams: SmartRequestParams) {
 	} catch (e) {
 		stateRef.prevReqFinishedAtMillis = currentTimeMillis();
 
-		//@ts-ignore
-		if (e instanceof java.net.ConnectException) {
+		if (e instanceof ConnectException) {
 			log.warning(e.message + ': on url:' + url/*, e*/); // Don't want stacktrace
-			//@ts-ignore
-		} else if (e instanceof java.net.SocketTimeoutException) {
+		} else if (e instanceof SocketTimeoutException) {
 			if(e.message === 'connect timed out') {
 				log.warning(e.message + ': connectionTimeout ' + connectionTimeout + 'ms exceeded on url ' + url/*, e*/); // Don't want stacktrace
 			} else if (e.message === 'timeout') {
@@ -108,8 +112,7 @@ export function smartRequest(smartRequestParams: SmartRequestParams) {
 			} else {
 				log.warning('java.net.SocketTimeoutException with unknown message:' + e.message, e);
 			}
-			//@ts-ignore
-		} else if (e instanceof java.lang.NullPointerException) {
+		} else if (e instanceof NullPointerException) {
 			log.error('java.lang.NullPointerException with message:' + e.message, e);
 		} else {
 			// TODO java.lang.RuntimeException: SSL peer shut down incorrectly

--- a/src/test/java/com/enonic/lib/explorer/SmartRequestTest.java
+++ b/src/test/java/com/enonic/lib/explorer/SmartRequestTest.java
@@ -1,0 +1,13 @@
+package com.enonic.lib.explorer;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class SmartRequestTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/smartRequest-test.js";
+    }
+}

--- a/src/test/resources/lib/http-client.js
+++ b/src/test/resources/lib/http-client.js
@@ -1,0 +1,24 @@
+var errorToThrow = null;
+var responseToReturn = null;
+
+exports.request = function () {
+    if (errorToThrow) {
+        throw errorToThrow;
+    }
+    return responseToReturn;
+};
+
+exports.__throw = function (error) {
+    errorToThrow = error;
+    responseToReturn = null;
+};
+
+exports.__respondWith = function (response) {
+    responseToReturn = response;
+    errorToThrow = null;
+};
+
+exports.__reset = function () {
+    errorToThrow = null;
+    responseToReturn = null;
+};

--- a/src/test/resources/lib/xp/task.js
+++ b/src/test/resources/lib/xp/task.js
@@ -1,0 +1,2 @@
+exports.sleep = function () {
+};

--- a/src/test/resources/test/smartRequest-test.js
+++ b/src/test/resources/test/smartRequest-test.js
@@ -1,0 +1,51 @@
+var assert = require('/lib/xp/testing');
+var httpClientMock = require('/lib/http-client');
+var smartRequest = require('/lib/explorer/http/client/smartRequest').smartRequest;
+
+var ConnectException = Java.type('java.net.ConnectException');
+var SocketTimeoutException = Java.type('java.net.SocketTimeoutException');
+var NullPointerException = Java.type('java.lang.NullPointerException');
+var RuntimeException = Java.type('java.lang.RuntimeException');
+
+exports.before = function () {
+    httpClientMock.__reset();
+};
+
+exports.testConnectExceptionIsHandledAndRethrown = function () {
+    httpClientMock.__throw(new ConnectException('simulated connect failure'));
+    var thrown = assert.assertThrows(function () {
+        smartRequest({url: 'http://localhost/', retries: 0, delay: 0});
+    });
+    assert.assertTrue(thrown instanceof ConnectException, 'expected the ConnectException to propagate');
+};
+
+exports.testSocketTimeoutExceptionIsHandledAndRethrown = function () {
+    httpClientMock.__throw(new SocketTimeoutException('connect timed out'));
+    var thrown = assert.assertThrows(function () {
+        smartRequest({url: 'http://localhost/', retries: 0, delay: 0});
+    });
+    assert.assertTrue(thrown instanceof SocketTimeoutException, 'expected the SocketTimeoutException to propagate');
+};
+
+exports.testNullPointerExceptionIsHandledAndRethrown = function () {
+    httpClientMock.__throw(new NullPointerException('simulated npe'));
+    var thrown = assert.assertThrows(function () {
+        smartRequest({url: 'http://localhost/', retries: 0, delay: 0});
+    });
+    assert.assertTrue(thrown instanceof NullPointerException, 'expected the NullPointerException to propagate');
+};
+
+exports.testUnhandledErrorIsRethrown = function () {
+    httpClientMock.__throw(new RuntimeException('simulated unhandled error'));
+    var thrown = assert.assertThrows(function () {
+        smartRequest({url: 'http://localhost/', retries: 0, delay: 0});
+    });
+    assert.assertTrue(thrown instanceof RuntimeException, 'expected the RuntimeException to propagate');
+};
+
+exports.testSuccessfulRequestReturnsResponse = function () {
+    httpClientMock.__respondWith({status: 200, body: 'ok'});
+    var response = smartRequest({url: 'http://localhost/', retries: 0, delay: 0});
+    assert.assertEquals(200, response.status);
+    assert.assertEquals('ok', response.body);
+};


### PR DESCRIPTION
Fixes #425

## Java package globals

`smartRequest.ts` matched connection errors with the Nashorn `java.*` package
globals (`java.net.ConnectException`, `java.net.SocketTimeoutException`,
`java.lang.NullPointerException`). Those globals are a Nashorn feature that
GraalJS only exposes under nashorn-compat, so the `instanceof` checks break once
that escape hatch is gone. They are now hoisted, constant `Java.type(...)`
lookups (standard GraalJS interop — XP configures `allowHostClassLookup`),
exactly as the issue prescribes. `app-explorer` reaches this same file through
its `symlinks/lib-explorer` symlink, so it is fixed there too.

## Tests on both engines

Added the dual-engine wiring from the issue (mirroring enonic/lib-sql#154):
`testRuntimeOnly org.graalvm.polyglot:js` and a `testGraalJs` task that runs
alongside the Nashorn `test` task via `check`. The new `SmartRequestTest`
(`ScriptRunnerSupport`) loads the compiled `smartRequest` bundle and drives
every catch branch — `ConnectException` / `SocketTimeoutException` /
`NullPointerException` / unhandled — plus the happy path.

Verified locally with the platform built from
`enonic/xp@claude/graaljs-support-limitations-pzu6z8` to mavenLocal (GraalVM CE 25):

- `:test` (Nashorn) — 5/5 green
- `:testGraalJs` (GraalJS) — 5/5 green
- `npm test` (Jest) — 542/542 green; `tsc --noEmit` clean

## Draft

Needs the `ScriptRunnerSupport` fix from enonic/xp#12198, hence
`xpVersion=8.1.0-SNAPSHOT`. **CI `testGraalJs` stays red until #12198 is merged
and a fresh 8.1.0-SNAPSHOT is published** — on the currently published snapshot
`ScriptRunnerSupport.findTestNames()` tears down the shared script executor
during test discovery, so the GraalJS run fails with
`IllegalStateException` / `PolyglotEngineException` before the assertions run
(the Nashorn `:test` run is unaffected). Kept as a draft until then.
